### PR TITLE
EASY-2002: add version to baseurl resource

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
@@ -24,9 +24,9 @@ import nl.knaw.dans.lib.logging.servlet._
 import org.eclipse.jetty.http.HttpStatus._
 import org.scalatra._
 import org.scalatra.auth.strategy.BasicAuthStrategy.BasicAuthRequest
+import scalaj.http.HttpResponse
 
 import scala.util.{ Failure, Success, Try }
-import scalaj.http.HttpResponse
 
 class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet with ServletLogger with PlainLogFormatter with DebugEnhancedLogging {
   logger.info("File Download Servlet running...")
@@ -35,7 +35,7 @@ class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet with Ser
 
   get("/") {
     contentType = "text/plain"
-    Ok("EASY Download Service running...").logResponse
+    Ok(s"EASY Download Service running v${ app.configuration.version }.").logResponse
   }
 
   get(s"/ark:/$naan/:uuid/*") {

--- a/src/test/scala/nl.knaw.dans.easy.download/ServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.download/ServletSpec.scala
@@ -36,10 +36,9 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer
   private val naan = "123456"
   private val app = new EasyDownloadApp {
     // mocking at a low level to test the chain of error handling
-
     override val http: HttpWorker = mock[HttpWorker]
     override val authentication: Authentication = mock[Authentication]
-    override lazy val configuration: Configuration = new Configuration("", new PropertiesConfiguration() {
+    override lazy val configuration: Configuration = new Configuration("1.0.0", new PropertiesConfiguration() {
       addProperty("bag-store.url", "http://localhost:20110/")
       addProperty("auth-info.url", "http://localhost:20170/")
       addProperty("ark.name-assigning-authority-number", naan)
@@ -61,7 +60,7 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer
 
   "get /" should "return the message that the service is running" in {
     get("/") {
-      body shouldBe "EASY Download Service running..."
+      body shouldBe "EASY Download Service running v1.0.0."
       status shouldBe OK_200
     }
   }


### PR DESCRIPTION
Fixes EASY-2002 add version to baseurl resource

#### When applied it will
* add version to baseurl resource


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-SOLR                      | [PR#37](https://github.com/DANS-KNAW/easy-solr4files-index/pull/37#pullrequestreview-212261770)     | ..