### PR TITLE
EASY-2056: use new servlet-logging features from dans-scala-lib v1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.5.0</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>


### PR DESCRIPTION
Fixes EASY-2056

#### When applied it will
* no longer use `.logResponse` to log the servlet response
* add `LogResponseBodyOnError` trait to servlet definition

@DANS-KNAW/easy for review