### PR TITLE
EASY-2021 Corrigeer aanroepen van bag-store op nieuwe percent-encoding regels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.5.0</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.download/components/AuthorisationComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/components/AuthorisationComponent.scala
@@ -20,6 +20,7 @@ import java.nio.file.Path
 import java.util.UUID
 
 import nl.knaw.dans.easy.download._
+import nl.knaw.dans.lib.encode.PathEncoding
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.json4s._
 
@@ -37,7 +38,7 @@ trait AuthorisationComponent extends DebugEnhancedLogging {
 
     def getFileItem(bagId: UUID, path: Path): Try[FileItem] = {
       for {
-        f <- Try(escapePath(path))
+        f <- Try(path.escapePath)
         uri = baseUri.resolve(s"$bagId/$f")
         jsonString <- http.getHttpAsString(uri)
         jsonOneLiner = jsonString.toOneLiner

--- a/src/main/scala/nl.knaw.dans.easy.download/components/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/components/BagStoreComponent.scala
@@ -19,7 +19,8 @@ import java.net.URI
 import java.nio.file.Path
 import java.util.UUID
 
-import nl.knaw.dans.easy.download.{ OutputStreamProvider, escapePath }
+import nl.knaw.dans.easy.download.OutputStreamProvider
+import nl.knaw.dans.lib.encode.PathEncoding
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 import scala.util.Try
@@ -34,7 +35,7 @@ trait BagStoreComponent extends DebugEnhancedLogging {
 
     def copyStream(bagId: UUID, path: Path): OutputStreamProvider => Try[Unit] = { outputStreamProducer =>
       for {
-        f <- Try(escapePath(path))
+        f <- Try(path.escapePath)
         uri <- Try(baseUri.resolve(s"bags/$bagId/$f"))
         _ <- http.copyHttpStream(uri)(outputStreamProducer)
       } yield ()

--- a/src/main/scala/nl.knaw.dans.easy.download/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/package.scala
@@ -16,16 +16,12 @@
 package nl.knaw.dans.easy
 
 import java.io.OutputStream
-import java.nio.file.Path
 
-import com.google.common.net.UrlEscapers
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
-import scala.collection.JavaConverters._
 import scalaj.http.HttpResponse
 
 package object download extends DebugEnhancedLogging {
-  private val pathEscaper = UrlEscapers.urlPathSegmentEscaper()
 
   type FeedBackMessage = String
   type OutputStreamProvider = () => OutputStream
@@ -48,10 +44,6 @@ package object download extends DebugEnhancedLogging {
   case class AuthenticationTypeNotSupportedException(cause: Throwable)
     extends Exception(cause.getMessage, cause) {
     logger.info(cause.getMessage)
-  }
-
-  def escapePath(path: Path): String = {
-    path.asScala.map(_.toString).map(pathEscaper.escape).mkString("/")
   }
 
   implicit class RichString(val s: String) extends AnyVal {

--- a/src/test/scala/nl.knaw.dans.easy.download/ServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.download/ServletSpec.scala
@@ -19,6 +19,7 @@ import java.net.URI
 import java.nio.file.{ Path, Paths }
 import java.util.UUID
 
+import nl.knaw.dans.lib.encode.PathEncoding
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.eclipse.jetty.http.HttpStatus._
 import org.scalamock.scalatest.MockFactory
@@ -47,11 +48,11 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer
   addServlet(new EasyDownloadServlet(app), "/*")
 
   private def expectDownloadStream(path: Path) = {
-    (app.http.copyHttpStream(_: URI)) expects new URI(s"http://localhost:20110/bags/$uuid/$path") once()
+    (app.http.copyHttpStream(_: URI)) expects new URI(s"http://localhost:20110/bags/$uuid/${ path.escapePath }") once()
   }
 
   private def expectAuthorisation(path: Path) = {
-    (app.http.getHttpAsString(_: URI)) expects new URI(s"http://localhost:20170/$uuid/$path") once()
+    (app.http.getHttpAsString(_: URI)) expects new URI(s"http://localhost:20170/$uuid/${ path.escapePath }") once()
   }
 
   private def expectAuthentication() = {

--- a/src/test/scala/nl.knaw.dans.easy.download/components/AuthorisationComponentSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.download/components/AuthorisationComponentSpec.scala
@@ -19,6 +19,7 @@ import java.net.URI
 import java.nio.file.{ Path, Paths }
 import java.util.UUID
 
+import nl.knaw.dans.lib.encode.PathEncoding
 import nl.knaw.dans.easy.download.TestSupportFixture
 import nl.knaw.dans.easy.download.components.RightsFor._
 import org.scalamock.scalatest.MockFactory
@@ -39,14 +40,14 @@ class AuthorisationComponentSpec extends TestSupportFixture with MockFactory {
   private val uuid = UUID.randomUUID()
 
   private def expectAuthInfoRequest(path: Path) = {
-    (wiring.http.getHttpAsString(_: URI)) expects wiring.authorisation.baseUri.resolve(s"$uuid/$path") once()
+    (wiring.http.getHttpAsString(_: URI)) expects wiring.authorisation.baseUri.resolve(s"$uuid/${path.escapePath}") once()
   }
 
   "getAuthInfo" should "parse the service response" in {
     val path = Paths.get("some.file")
     expectAuthInfoRequest(path) returning Success(
       s"""{
-         |  "itemId":"$uuid/some.file",
+         |  "itemId":"$uuid/some%2Efile",
          |  "owner":"someone",
          |  "dateAvailable":"1992-07-30",
          |  "accessibleTo":"KNOWN",


### PR DESCRIPTION
#### When applied it
* replaces calls to `Guava UrlEscapers` methods with calls to `dans-scala-lib `encoding methods
  (which in turn make use of `Guava PercentEscaper`)

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-auth-info                 | [DANS-KNAW/easy-auth-info/pull/23] | ..
easy-bag-store                | [DANS-KNAW/easy-bag-store/pull/91] | ..
easy-ingest-flow             | [DANS-KNAW/easy-ingest-flow/pull/109] | ..
easy-solr4files-index      | [DANS-KNAW/easy-solr4files-index/pull/39] | ..
easy-validate-dans-bag | [DANS-KNAW/easy-validate-dans-bag/pull/57] | ..