### PR TITLE
EASY-2400, EASY-2402: Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 easy-download
 ===========
+[![Build Status](https://travis-ci.org/DANS-KNAW/easy-download.png?branch=master)](https://travis-ci.org/DANS-KNAW/easy-download)
 
-for documentation see: https://dans-knaw.github.io/easy-download
+Welcome
+--------
+
+Welcome to te ```easy-download``` project, which is used to download items directly from the bag stores.
+The project has documentation for both the [command line interface](https://dans-knaw.github.io/easy-download/01_manual.html)
+as well as the [API definitions](https://dans-knaw.github.io/easy-download/api.html).
+

--- a/docs/01_manual.md
+++ b/docs/01_manual.md
@@ -32,49 +32,17 @@ ARGUMENTS
       -h, --help   Show help message
     ---
 
-HTTP service
-------------
-
-When started with the sub-command `run-service` a REST API becomes available with HTTP method `GET` only.
-In a path pattern `*` refers to any completion of the path, placeholders for variables _start_ with a colon,
-and NAAN represents the configured _name assigning authority number_.
-
-Path                 | Action
----------------------|------------------------------------
-`/`                  | Return a simple message to indicate that the service is up: "File Download Servlet running..."
-`/ark:/NAAN/:uuid/*` | Return the contents of the file with bag-id `:uuid` and bag local path `*`
-
-
-EXAMPLES
---------
-
-    curl http://test.dans.knaw.nl:20160/
-    curl -u user:password http://test.dans.knaw.nl:20160/ark:/73189/40594b6d-8378-4260-b96b-13b57beadf7c/data/pakbon.xml
-
-
 INSTALLATION AND CONFIGURATION
 ------------------------------
 
+Currently this project is built only as an RPM package for RHEL7/CentOS7 and later. The RPM will install the binaries to
+`/opt/dans.knaw.nl/easy-download`, the configuration files to `/etc/opt/dans.knaw.nl/easy-download`,
+and will install the service script for `systemd`.
 
 ### Depending on services
 
 * [easy-bag-store](https://github.com/DANS-KNAW/easy-bag-store/)
 
-
-### Installation steps
-
-1. Unzip the tarball to a directory of your choice, typically `/usr/local/`
-2. A new directory called easy-download-<version> will be created
-3. Add the command script to your `PATH` environment variable by creating a symbolic link to it from a directory that is
-   on the path, e.g.
-
-        ln -s /usr/local/easy-download-<version>/bin/easy-download /usr/bin
-
-
-### Configuration
-
-General configuration settings can be set in `cfg/application.properties` and logging can be configured
-in `cfg/logback.xml`. The available settings are explained in comments in aforementioned files.
 
 ### Security advice
 
@@ -89,9 +57,14 @@ Prerequisites:
 
 * Java 8 or higher
 * Maven 3.3.3 or higher
+* RPM
 
 Steps:
 
         git clone https://github.com/DANS-KNAW/easy-download.git
         cd easy-download
         mvn install
+
+If the `rpm` executable is found at `/usr/local/bin/rpm`, the build profile that includes the RPM
+packaging will be activated. If `rpm` is available, but at a different path, then activate it by using
+Maven's `-P` switch: `mvn -Pprm install`.


### PR DESCRIPTION
Fixes EASY-2402 & EASY-2400

#### When applied it will
* Remove duplicate http documentation
* Pull Readme installation instructions in line with [this](https://github.com/janvanmansum/easy-module-archetype/tree/22fb71c9274705e6f8d12e8e622d9486639d7b1a/src/main/resources/archetype-resources)

#### Where should the reviewer @DANS-KNAW/easy start?
