### PR TITLE
EASY-1478: Downloads MUST include the license for the files

### DIFF
--- a/debug-init-env.sh
+++ b/debug-init-env.sh
@@ -15,7 +15,14 @@
 # limitations under the License.
 #
 
+HOMEDIR=home
+DATADIR=data
+
+echo "Copying licenses to $HOMEDIR/cfg..."
+mvn generate-resources
+LICENSES=target/easy-licenses/licenses
+cp -r "$LICENSES" $HOMEDIR/cfg/lic
+
 echo -n "Pre-creating log..."
-TEMPDIR=data
-touch $TEMPDIR/easy-download.log
+touch $DATADIR/easy-download.log
 echo "OK"

--- a/pom.xml
+++ b/pom.xml
@@ -189,10 +189,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>rpm-maven-plugin</artifactId>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>rpm-maven-plugin</artifactId>
                         <configuration>
                             <group>Applications/Archiving</group>
                             <mappings combine.children="append">

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <inceptionYear>2017</inceptionYear>
     <properties>
         <main-class>nl.knaw.dans.easy.download.Command</main-class>
+        <easy.licenses.version>1.0.1</easy.licenses.version>
     </properties>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>
@@ -147,6 +148,33 @@
         </repository>
     </repositories>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>resources</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>nl.knaw.dans.easy</groupId>
+                                    <artifactId>easy-licenses</artifactId>
+                                    <version>${easy.licenses.version}</version>
+                                    <outputDirectory>${project.build.directory}/easy-licenses</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>rpm</id>
@@ -161,6 +189,24 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>rpm-maven-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>rpm-maven-plugin</artifactId>
+                        <configuration>
+                            <group>Applications/Archiving</group>
+                            <mappings combine.children="append">
+                                <mapping>
+                                    <directory>/etc/opt/${dans-provider-name}/${project.artifactId}/lic</directory>
+                                    <configuration>${rpm-replace-configuration}</configuration>
+                                    <sources>
+                                        <source>
+                                            <location>target/easy-licenses/licenses</location>
+                                        </source>
+                                    </sources>
+                                </mapping>
+                            </mappings>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/src/main/scala/nl.knaw.dans.easy.download/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/Configuration.scala
@@ -23,7 +23,7 @@ import resource.managed
 
 import scala.io.Source
 
-case class Configuration(version: String, properties: PropertiesConfiguration)
+case class Configuration(version: String, properties: PropertiesConfiguration, licenses: PropertiesConfiguration)
 
 object Configuration extends DebugEnhancedLogging {
 
@@ -41,7 +41,8 @@ object Configuration extends DebugEnhancedLogging {
       properties = new PropertiesConfiguration() {
         setDelimiterParsingDisabled(true)
         load(cfgPath.resolve("application.properties").toFile)
-      }
+      },
+      licenses = new PropertiesConfiguration(cfgPath.resolve("lic/licenses.properties").toFile)
     )
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
@@ -15,8 +15,9 @@
  */
 package nl.knaw.dans.easy.download
 
+import nl.knaw.dans.easy.download.components.License
 import java.io.FileNotFoundException
-import java.nio.file.Paths
+import java.nio.file.{ Path, Paths }
 import java.util.UUID
 
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
@@ -48,7 +49,7 @@ class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet
     logger.info(s"file download requested by $userName for $params")
 
     (getUUID, getPath, app.authenticate(authRequest)) match {
-      case (Success(uuid), Success(Some(path)), Success(user)) => respond(s"$uuid/$path", app.downloadFile(uuid, path, user, () => response.outputStream))
+      case (Success(uuid), Success(Some(path)), Success(user)) => respond(uuid, path, app.downloadFile(uuid, path, user, () => response.outputStream))
       case (Success(_), Success(None), _) => BadRequest("file path is empty")
       case (Failure(t), _, _) => BadRequest(t.getMessage) // invalid uuid
       case (_, Failure(t), _) => BadRequest(t.getMessage) // invalid path
@@ -69,17 +70,32 @@ class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet
     multiParams("splat").find(!_.trim.isEmpty).map(Paths.get(_))
   }
 
-  private def respond(path: String, copyResult: Try[Unit]) = {
+  private def respond(uuid: UUID, path: Path, copyResult: Try[Unit]) = {
     copyResult match {
-      case Success(()) => Ok()
+      case Success(()) => sendOkResponse(uuid, path)
       case Failure(HttpStatusException(message, HttpResponse(_, SERVICE_UNAVAILABLE_503, _))) => ServiceUnavailable(message)
       case Failure(HttpStatusException(message, HttpResponse(_, REQUEST_TIMEOUT_408, _))) => RequestTimeout(message)
-      case Failure(HttpStatusException(_, HttpResponse(_, NOT_FOUND_404, _))) => NotFound(s"not found: $path")
+      case Failure(HttpStatusException(_, HttpResponse(_, NOT_FOUND_404, _))) => NotFound(s"not found: $uuid/$path")
       case Failure(NotAccessibleException(message)) => Forbidden(message)
-      case Failure(_: FileNotFoundException) => NotFound(s"not found: $path") // in fact: not visible
+      case Failure(_: FileNotFoundException) => NotFound(s"not found: $uuid/$path") // in fact: not visible
       case Failure(t) =>
         logger.error(t.getMessage, t)
         InternalServerError("not expected exception")
     }
+  }
+
+  private def sendOkResponse(uuid: UUID, path: Path): Unit = {
+    val licenseLinkText = getLicenseLinkText(uuid, path).getOrElse(None)
+    if (licenseLinkText.nonEmpty) {
+      response.addHeader("Link", licenseLinkText.get)
+    }
+    Ok()
+  }
+
+  private def getLicenseLinkText(uuid: UUID, path: Path): Try[Option[String]] = {
+    for {
+      fileItem <- app.getFileItem(uuid, path)
+      licenseLinkText <- new License(fileItem, app.configuration.licenses).getLicenseLinkText
+    } yield licenseLinkText
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
@@ -15,11 +15,11 @@
  */
 package nl.knaw.dans.easy.download
 
-import nl.knaw.dans.easy.download.components.License
 import java.io.FileNotFoundException
 import java.nio.file.{ Path, Paths }
 import java.util.UUID
 
+import nl.knaw.dans.easy.download.components.License
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.lib.logging.servlet._
 import org.eclipse.jetty.http.HttpStatus._
@@ -86,9 +86,7 @@ class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet
 
   private def sendOkResponse(uuid: UUID, path: Path): Unit = {
     val licenseLinkText = getLicenseLinkText(uuid, path).getOrElse(None)
-    if (licenseLinkText.nonEmpty) {
-      response.addHeader("Link", licenseLinkText.get)
-    }
+    licenseLinkText.foreach(response.addHeader("Link", _))
     Ok()
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.download/components/FileItem.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/components/FileItem.scala
@@ -49,6 +49,10 @@ case class FileItem(itemId: String,
     else Failure(NotAccessibleException(s"Download not allowed of: $itemId")) // might require group/permission
   }
 
+  def isOpenAccess: Boolean = {
+    accessibleTo == ANONYMOUS
+  }
+
   private def isOwnedBy(user: Option[User]): Boolean = {
     user.exists(_.id == owner)
   }

--- a/src/main/scala/nl.knaw.dans.easy.download/components/License.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/components/License.scala
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2017 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.download.components
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.apache.commons.configuration.PropertiesConfiguration
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+/**
+ * @param file fileItem of the file to download
+ */
+
+class License(file: FileItem, licenses: PropertiesConfiguration) extends DebugEnhancedLogging {
+
+  private val OPEN_ACCESS_LICENSE = "http://creativecommons.org/publicdomain/zero/1.0"
+  private val DANS_LICENSE = "http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSGeneralconditionsofuseUKDEF.pdf"
+
+  private val license = getLicense(file, licenses)
+
+  def getLicenseLinkText: Try[Option[String]] = Try {
+    if (license.nonEmpty) {
+      val (licenseAddress, licenseTitle) = license.get
+      Some("<%s>; rel=\"%s\"; title=\"%s\"".format(licenseAddress, "license", licenseTitle))
+    }
+    else
+      None
+  }
+
+  private def getLicense(file: FileItem, licenses: PropertiesConfiguration): Option[(String, String)] = {
+    val keys = licenses.getKeys.asScala.toSet
+    val licenseKey = if (file.isOpenAccess) OPEN_ACCESS_LICENSE
+                     else DANS_LICENSE
+
+    val key = keys.find(_.equals(licenseKey))
+    if (key.isEmpty) licenseNotFound(licenseKey)
+    else Some(key.get, licenses.getProperty(key.get).toString)
+  }
+
+  private def licenseNotFound(licenseKey: String): Option[(String, String)] = {
+    logger.error("No license found with key: " + licenseKey)
+    None
+  }
+}
+
+

--- a/src/test/scala/nl.knaw.dans.easy.download/ServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.download/ServletSpec.scala
@@ -27,6 +27,7 @@ import org.scalatra.auth.strategy.BasicAuthStrategy.BasicAuthRequest
 import org.scalatra.test.EmbeddedJettyContainer
 import org.scalatra.test.scalatest.ScalatraSuite
 
+import scala.language.postfixOps
 import scala.util.Success
 
 class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer

--- a/src/test/scala/nl.knaw.dans.easy.download/ServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.download/ServletSpec.scala
@@ -39,11 +39,17 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer
     // mocking at a low level to test the chain of error handling
     override val http: HttpWorker = mock[HttpWorker]
     override val authentication: Authentication = mock[Authentication]
-    override lazy val configuration: Configuration = new Configuration("1.0.0", new PropertiesConfiguration() {
-      addProperty("bag-store.url", "http://localhost:20110/")
-      addProperty("auth-info.url", "http://localhost:20170/")
-      addProperty("ark.name-assigning-authority-number", naan)
-    })
+    override lazy val configuration: Configuration = new Configuration("1.0.0",
+      new PropertiesConfiguration() {
+        addProperty("bag-store.url", "http://localhost:20110/")
+        addProperty("auth-info.url", "http://localhost:20170/")
+        addProperty("ark.name-assigning-authority-number", naan)
+      },
+      new PropertiesConfiguration() {
+        addProperty("http://creativecommons.org/publicdomain/zero/1.0", "CC0-1.0.html")
+        addProperty("http://creativecommons.org/licenses/by/4.0", "CC-BY-4.0.html")
+        addProperty("http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSGeneralconditionsofuseUKDEF.pdf", "DANSGeneralconditionsofuseUKDEF.pdf")
+      })
   }
   addServlet(new EasyDownloadServlet(app), "/*")
 


### PR DESCRIPTION
Fixes EASY-1478
#### When applied it will
* add a `license link` to the `headers` of download response
* when dataset is `Open Access`, it will add a link to the `Open Access license`
  (Link: <http://creativecommons.org/publicdomain/zero/1.0>; rel="license"; title="CC0-1.0.html")
* when dataset is **not** `Open Access`, it will add a link to DANS license
  (Link: <http://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSGeneralconditionsofuseUKDEF.pdf>; rel="license"; title="DANSGeneralconditionsofuseUKDEF.pdf")
* it will log an error if the license is not found
#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
* deploy easy-download on deasy
* fire a curl query, e.g. curl -v -u easyadmin:easyadmin http://deasy.dans.knaw.nl:20160/ark:/73189/-bag-id-/data/README.md
* check the headers

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
