### PR TITLE
EASY-2424: Bad credentials moet bestanden met anonymous access kunnen opvragen

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadApp.scala
@@ -37,11 +37,12 @@ trait EasyDownloadApp extends DebugEnhancedLogging with ApplicationWiring {
    */
   def downloadFile(bagId: UUID,
                    path: Path,
+                   fileItem: Try[FileItem],
                    user: Option[User],
                    outputStreamProducer: () => OutputStream
                   ): Try[Unit] = {
     for {
-      fileItem <- getFileItem(bagId, path)
+      fileItem <- fileItem
       _ <- fileItem.availableFor(user)
       _ <- bagStore.copyStream(bagId, path)(outputStreamProducer).recoverWith {
         case HttpStatusException(_, HttpResponse(_, NOT_FOUND_404, _)) =>

--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
@@ -98,7 +98,7 @@ class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet
     }
   }
 
-  private def sendOkResponse(uuid: UUID, path: Path): Unit = {
+  private def sendOkResponse(uuid: UUID, path: Path) = {
     val licenseLinkText = getLicenseLinkText(uuid, path).getOrElse(None)
     licenseLinkText.foreach(response.addHeader("Link", _))
     Ok()

--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
@@ -65,6 +65,9 @@ class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet
   }
 
   private def download(authRequest: BasicAuthRequest, userName: String, uuid: UUID, path: Path) = {
+    // When fileItem is a Failure, it is transformed into a None for getUser(...); in that case authentication is guaranteed to be performed.
+    // If authentication succeeds, the original error caused by fileItem surfaces from app.downloadFile(...);
+    // if authentication fails, priority is given to that error above the error in fileItem.    val fileItem = app.authorisation.getFileItem(uuid, path)
     val fileItem = app.authorisation.getFileItem(uuid, path)
     getUser(authRequest, userName, fileItem.toOption) match {
       case Success(user) => respond(uuid, path, app.downloadFile(uuid, path, fileItem, user, () => response.outputStream))

--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
@@ -67,7 +67,7 @@ class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet
   private def download(authRequest: BasicAuthRequest, userName: String, uuid: UUID, path: Path) = {
     // When fileItem is a Failure, it is transformed into a None for getUser(...); in that case authentication is guaranteed to be performed.
     // If authentication succeeds, the original error caused by fileItem surfaces from app.downloadFile(...);
-    // if authentication fails, priority is given to that error above the error in fileItem.    val fileItem = app.authorisation.getFileItem(uuid, path)
+    // if authentication fails, priority is given to that error above the error in fileItem.
     val fileItem = app.authorisation.getFileItem(uuid, path)
     getUser(authRequest, userName, fileItem.toOption) match {
       case Success(user) => respond(uuid, path, app.downloadFile(uuid, path, fileItem, user, () => response.outputStream))


### PR DESCRIPTION
Fixes EASY-2424

#### When applied it will
* execute user authentication only when the file is not Open Access

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
See the instructions in the Jira issue. But **notice**: the example file in the Jira issue should still after this change return 401 error code, because the dataset is `NO_ACCESS`. You have to test it with an `OPEN_ACCESS` dataset.

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
