### PR TITLE
EASY-2426: Ongeldige UUID zou een 404 moeten geven

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
@@ -51,7 +51,7 @@ class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet
     (getUUID, getPath) match {
       case (Success(uuid), Success(Some(path))) => download(authRequest, userName, uuid, path)
       case (Success(_), Success(None)) => BadRequest("file path is empty")
-      case (Failure(t), _) => BadRequest(t.getMessage) // invalid uuid
+      case (Failure(t), _) => NotFound(t.getMessage) // invalid uuid
       case (_, Failure(t)) => BadRequest(t.getMessage) // invalid path
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.download/ServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.download/ServletSpec.scala
@@ -218,7 +218,7 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer
     expectAuthentication(0)
     get(s"ark:/$naan/1-2-3-4-5-6/some.file") {
       body shouldBe "Invalid UUID string: 1-2-3-4-5-6"
-      status shouldBe BAD_REQUEST_400
+      status shouldBe NOT_FOUND_404
     }
   }
 


### PR DESCRIPTION
Fixes EASY-2426

#### When applied it will
* return `404` when UUID is invalid

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
curl -i http://deasy.dans.knaw.nl:20160/ark:/73189/invalidUUID/data/a/deeper/path/With%20some%20file%2Etxt.
#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
