### PR TITLE
EASY-2348. Fixed bug in unit test caused by pr #44

### DIFF
--- a/src/test/scala/nl.knaw.dans.easy.download/ServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.download/ServletSpec.scala
@@ -244,7 +244,9 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer
          |  "owner":"someone",
          |  "dateAvailable":"1992-07-30",
          |  "accessibleTo":"ANONYMOUS",
-         |  "visibleTo":"ANONYMOUS"
+         |  "visibleTo":"ANONYMOUS",
+         |  "licenseKey":"",
+         |  "licenseTitle":""
          |}""".stripMargin
     )
     get(s"ark:/$naan/$uuidWithoutHyphens/$path") {


### PR DESCRIPTION
Fixed bug in unit test caused by pr #44

Btw it took me a lot of time to find out what was wrong. I think the main reason was that errors in the file item JSON are silently converted to "there is no fileitem" by the `.toOption`.

#### Where should the reviewer @DANS-KNAW/easy start?

