### PR TITLE
EASY-2348: refactorings and extra test

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
@@ -58,18 +58,15 @@ class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet
   }
 
   private def getUUID = {
-    correctHyphenation(params("uuid")).toUUID match {
-      case Right(uuid) => Success(uuid)
-      case Left(error) => Failure(error)
-    }
+    correctHyphenation(params("uuid")).toUUID.toTry
   }
 
-  private def correctHyphenation(uuid: String): String =  {
+  private def correctHyphenation(uuid: String): String = {
     // In ARK identifiers hyphens are considered to be insignificant, that is why we here
     // add the hyphens to a uuid string that doesn't contain any hyphens and whose length is 32 characters
     // (lenghth of a valid UUID without hyphens).
     if (!uuid.contains("-") && uuid.length == 32)
-      s"${uuid.slice(0, 8)}-${uuid.slice(8, 12)}-${uuid.slice(12, 16)}-${uuid.slice(16, 20)}-${uuid.slice(20, 32)}"
+      s"${ uuid.slice(0, 8) }-${ uuid.slice(8, 12) }-${ uuid.slice(12, 16) }-${ uuid.slice(16, 20) }-${ uuid.slice(20, 32) }"
     else
       uuid
   }
@@ -121,6 +118,6 @@ class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet
   }
 
   private def getLicenseLinkText(fileItem: Try[FileItem]): Option[String] = {
-    fileItem.map(file => Some(s"""<${file.licenseKey}>; rel="license"; title="${file.licenseTitle}"""")).getOrElse(None)
+    fileItem.map(file => Some(s"""<${ file.licenseKey }>; rel="license"; title="${ file.licenseTitle }"""")).getOrElse(None)
   }
 }


### PR DESCRIPTION
Addendum to EASY-2348 and https://github.com/DANS-KNAW/easy-download/pull/44

#### When applied it will
* use the library's `.toTry` instead of our own pattern match
* apply formatting
* add an extra test as suggested by @janvanmansum in https://github.com/DANS-KNAW/easy-download/pull/44#discussion_r359300578

@DANS-KNAW/easy for review