### PR TITLE
EASY-2542: make *.sh scripts executable in RPM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,23 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>rpm-maven-plugin</artifactId>
+                        <configuration combine.children="override">
+                            <group>Application/Archiving</group>
+                            <mappings combine.children="append">
+                                <mapping>
+                                    <directory>/opt/${dans-provider-name}/${project.artifactId}/bin</directory>
+                                    <filemode>755</filemode>
+                                    <sources>
+                                        <source>
+                                            <location>src/main/assembly/dist/bin</location>
+                                            <includes>
+                                                <include>*.sh</include>
+                                            </includes>
+                                        </source>
+                                    </sources>
+                                </mapping>
+                            </mappings>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Fixes EASY-2542

#### When applied it will
* make `*.sh` scripts executable in RPM

@DANS-KNAW/easy for review