### PR TITLE
EASY-2333: easy-download service returns 500 instead of 503 when easy-auth-info or easy-bag-store are offline.

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadApp.scala
@@ -61,7 +61,10 @@ trait EasyDownloadApp extends DebugEnhancedLogging with ApplicationWiring {
   }
 
   def getFileItem(bagId: UUID, path: Path): Try[FileItem] = {
-    authorisation.getFileItem(bagId, path)
+    authorisation.getFileItem(bagId, path).recoverWith {
+      case t if (t.getMessage contains ("Connection refused")) =>
+        Failure(AuthenticationNotAvailableException(t))
+    }
   }
 
   def getDDM(bagId: UUID): Try[Elem] = {

--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadApp.scala
@@ -65,6 +65,8 @@ trait EasyDownloadApp extends DebugEnhancedLogging with ApplicationWiring {
     authorisation.getFileItem(bagId, path).recoverWith {
       case t: ConnectException =>
         Failure(AuthenticationNotAvailableException(t))
+      case t if (t.getMessage contains("500 Server Error")) =>
+        Failure(ServiceNotAvailableException(t))
     }
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadApp.scala
@@ -16,18 +16,19 @@
 package nl.knaw.dans.easy.download
 
 import java.io.OutputStream
+import java.net.ConnectException
 import java.nio.file.Path
 import java.util.UUID
 import javax.servlet.http.HttpServletRequest
 
 import nl.knaw.dans.easy.download.components.{ FileItem, Statistics, User }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-
 import org.eclipse.jetty.http.HttpStatus.NOT_FOUND_404
 import org.scalatra.auth.strategy.BasicAuthStrategy.BasicAuthRequest
 
 import scala.util.{ Failure, Try }
 import scalaj.http.HttpResponse
+
 import scala.xml.Elem
 
 trait EasyDownloadApp extends DebugEnhancedLogging with ApplicationWiring {
@@ -62,7 +63,7 @@ trait EasyDownloadApp extends DebugEnhancedLogging with ApplicationWiring {
 
   def getFileItem(bagId: UUID, path: Path): Try[FileItem] = {
     authorisation.getFileItem(bagId, path).recoverWith {
-      case t if (t.getMessage contains ("Connection refused")) =>
+      case t: ConnectException =>
         Failure(AuthenticationNotAvailableException(t))
     }
   }

--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
@@ -107,6 +107,7 @@ class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet
       case Failure(NotAccessibleException(message)) => Forbidden(message)
       case Failure(_: FileNotFoundException) => NotFound(s"not found: $uuid/$path") // in fact: not visible
       case Failure(AuthenticationNotAvailableException(_)) => ServiceUnavailable("Authentication service not available")
+      case Failure(ServiceNotAvailableException(_)) => ServiceUnavailable("Bag-store service not available")
       case Failure(t) =>
         logger.error(t.getMessage, t)
         InternalServerError("not expected exception")

--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
@@ -106,6 +106,7 @@ class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet
       case Failure(HttpStatusException(_, HttpResponse(_, NOT_FOUND_404, _))) => NotFound(s"not found: $uuid/$path")
       case Failure(NotAccessibleException(message)) => Forbidden(message)
       case Failure(_: FileNotFoundException) => NotFound(s"not found: $uuid/$path") // in fact: not visible
+      case Failure(AuthenticationNotAvailableException(_)) => ServiceUnavailable("Authentication service not available")
       case Failure(t) =>
         logger.error(t.getMessage, t)
         InternalServerError("not expected exception")

--- a/src/main/scala/nl.knaw.dans.easy.download/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/package.scala
@@ -41,6 +41,11 @@ package object download extends DebugEnhancedLogging {
     logger.info(cause.getMessage)
   }
 
+  case class ServiceNotAvailableException(cause: Throwable)
+    extends Exception(cause.getMessage, cause) {
+    logger.info(cause.getMessage)
+  }
+
   case class AuthenticationTypeNotSupportedException(cause: Throwable)
     extends Exception(cause.getMessage, cause) {
     logger.info(cause.getMessage)


### PR DESCRIPTION
Fixes EASY-2333

#### When applied it will
* returns `503` with message `Authentication service not available` when `easy-auth-info` is down
* returns `503` with message `Bag-store service not available` when `easy-bag-store` is down

**Notice**: I am not sure if this is the way to go.  The solution is based on how `easy-auth-info` and `easy-bag-store` now react.  When `easy-auth-info` is down, we get `ConnectException`.  When `easy-bag-store` is down, we get `500 Server Error `exception.

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
See the instructions in the Jira issue

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
