### PR TITLE
EASY-2342: Request met lege authentication credentials resulteert in 503

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
@@ -83,6 +83,8 @@ class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet
     getUser(authRequest, userName, fileItem.toOption) match {
       case Success(user) => respond(uuid, path, fileItem, app.downloadFile(request, uuid, path, fileItem, user, () => response.outputStream))
       case Failure(InvalidUserPasswordException(_, _)) => Unauthorized()
+      case Failure(InvalidNameAuthenticationException(_)) => Unauthorized()
+      case Failure(NoPasswordAuthenticationException(_)) => Unauthorized()
       case Failure(AuthenticationNotAvailableException(_)) => ServiceUnavailable("Authentication service not available, try anonymous download")
       case Failure(AuthenticationTypeNotSupportedException(_)) => BadRequest("Only anonymous download or basic authentication supported")
       case Failure(t) =>

--- a/src/main/scala/nl.knaw.dans.easy.download/components/AuthenticationComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/components/AuthenticationComponent.scala
@@ -16,12 +16,12 @@
 package nl.knaw.dans.easy.download.components
 
 import java.util
-import javax.naming.{ AuthenticationException, Context }
+
+import javax.naming.{ AuthenticationException, Context, InvalidNameException, OperationNotSupportedException }
 import javax.naming.directory.SearchControls.SUBTREE_SCOPE
 import javax.naming.directory.{ Attribute, SearchControls, SearchResult }
 import javax.naming.ldap.{ InitialLdapContext, LdapContext }
-
-import nl.knaw.dans.easy.download.{ AuthenticationNotAvailableException, AuthenticationTypeNotSupportedException, InvalidUserPasswordException }
+import nl.knaw.dans.easy.download.{ AuthenticationNotAvailableException, AuthenticationTypeNotSupportedException, InvalidNameAuthenticationException, InvalidUserPasswordException, NoPasswordAuthenticationException }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.scalatra.auth.strategy.BasicAuthStrategy.BasicAuthRequest
 import resource.managed
@@ -69,6 +69,8 @@ trait AuthenticationComponent extends DebugEnhancedLogging {
           .tried
       }.recoverWith {
         case t: AuthenticationException => Failure(InvalidUserPasswordException(userName, new Exception("invalid password", t)))
+        case t: InvalidNameException => Failure(InvalidNameAuthenticationException(t))
+        case t: OperationNotSupportedException if (password.isEmpty) => Failure(NoPasswordAuthenticationException(t))
         case t => Failure(AuthenticationNotAvailableException(t))
       }
 

--- a/src/main/scala/nl.knaw.dans.easy.download/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/package.scala
@@ -36,6 +36,16 @@ package object download extends DebugEnhancedLogging {
     logger.info(s"invalid credentials for $userName: ${ cause.getMessage }")
   }
 
+  case class InvalidNameAuthenticationException(cause: Throwable)
+    extends Exception(cause.getMessage, cause) {
+    logger.info(cause.getMessage)
+  }
+
+  case class NoPasswordAuthenticationException(cause: Throwable)
+    extends Exception(cause.getMessage, cause) {
+    logger.info(cause.getMessage)
+  }
+
   case class AuthenticationNotAvailableException(cause: Throwable)
     extends Exception(cause.getMessage, cause) {
     logger.info(cause.getMessage)


### PR DESCRIPTION
Fixes EASY-2342

#### When applied it will
* return `401` when `user id` is empty or `password` is empty


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
See the instructions in teh Jira issue

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
