### PR TITLE
EASY-2333: service not available response

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadApp.scala
@@ -44,12 +44,11 @@ trait EasyDownloadApp extends DebugEnhancedLogging with ApplicationWiring {
   def downloadFile(request: HttpServletRequest,
                    bagId: UUID,
                    path: Path,
-                   fileItem: Try[FileItem],
+                   fileItem: FileItem,
                    user: Option[User],
                    outputStreamProducer: () => OutputStream
                   ): Try[Unit] = {
     for {
-      fileItem <- fileItem
       _ <- fileItem.availableFor(user)
       _ <- bagStore.copyStream(bagId, path)(outputStreamProducer).recoverWith {
         case HttpStatusException(_, HttpResponse(_, NOT_FOUND_404, _)) =>

--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
@@ -110,6 +110,8 @@ class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet
 
   // overlap between errors from easy-auth-info and easy-bag-store is covered in this one function
   private def recoverAuthInfoOrDownload(uuid: UUID, path: Path)(e: Throwable): ActionResult = e match {
+    case ServiceNotAvailableException(e) => ServiceUnavailable(e.getMessage)
+    case AuthorisationNotAvailableException(e) => ServiceUnavailable(e.getMessage)
     case HttpStatusException(message, HttpResponse(_, SERVICE_UNAVAILABLE_503, _)) => ServiceUnavailable(message)
     case HttpStatusException(message, HttpResponse(_, REQUEST_TIMEOUT_408, _)) => RequestTimeout(message)
     case HttpStatusException(_, HttpResponse(_, NOT_FOUND_404, _)) => NotFound(s"not found: $uuid/$path")

--- a/src/main/scala/nl.knaw.dans.easy.download/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/package.scala
@@ -56,6 +56,16 @@ package object download extends DebugEnhancedLogging {
     logger.info(cause.getMessage)
   }
 
+  case class AuthorisationNotAvailableException(cause: Throwable)
+    extends Exception(cause.getMessage, cause) {
+    logger.info(cause.getMessage)
+  }
+
+  case class ServiceNotAvailableException(cause: Throwable)
+    extends Exception(cause.getMessage, cause) {
+    logger.info(cause.getMessage)
+  }
+
   implicit class RichString(val s: String) extends AnyVal {
 
     // TODO candidate for dans-scala-lib


### PR DESCRIPTION
Fixes EASY-2333

#### When applied it will
* do lots of refactoring in error handling
* catch a `ConnectException` and convert it to a `503` response

@DANS-KNAW/easy for review

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-auth-info                      | [PR#37](https://github.com/DANS-KNAW/easy-auth-info/pull/37)     | 
