### PR TITLE
EASY-2569: Make hyphens in UUID mandatory again

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -37,15 +37,16 @@ paths:
       summary: Returns the file specified by the file-id.
       description: |
         The file which is fetched is specified by the file-id.
-        The file-id is defined as the bag-id followed by the percent encoded relative path of the file in the bag.
-        In ARK (Archival Resource Key) Identifiers hyphens are considered to be insignificant. If the hyphens are missing in the bag-id,
-        the service will add them automatically. But if the bag-id contains hyphens, then it will be validated as such.
-        This service requires the item-id to refer to a payload file, it is unable to download directories and non-payload files:
+        The file-id is defined as the bag-id followed by the [percent encoded relative path of the file in the bag](https://dans-knaw.github.io/easy-bag-store/definitions/#item-id).
 
+        This service deviates from the [ARK-specs](https://n2t.net/e/arkspec.txt) in that the hyphens in the UUID part of URL *are* mandatory.
         ```
         example valid file-ids:
          40594b6d-8378-4260-b96b-13b57beadf7c/path/to/file
          40594b6d-8378-4260-b96b-13b57beadf7c/path/to/another%20file
+
+        not accepted, though it would be equivalent according to ARK:
+         40594b6d83784260b96b13b57beadf7c/path/to/file
          40594b6d83784260b96b13b57beadf7c/path/to/another%20file
         ```
 

--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
@@ -58,18 +58,18 @@ class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet
   }
 
   private def getUUID = {
-    correctHyphenation(params("uuid")).toUUID.toTry
+   params("uuid").toUUID.toTry
   }
 
-  private def correctHyphenation(uuid: String): String = {
-    // In ARK identifiers hyphens are considered to be insignificant, that is why we here
-    // add the hyphens to a uuid string that doesn't contain any hyphens and whose length is 32 characters
-    // (lenghth of a valid UUID without hyphens).
-    if (!uuid.contains("-") && uuid.length == 32)
-      s"${ uuid.slice(0, 8) }-${ uuid.slice(8, 12) }-${ uuid.slice(12, 16) }-${ uuid.slice(16, 20) }-${ uuid.slice(20, 32) }"
-    else
-      uuid
-  }
+//  private def correctHyphenation(uuid: String): String = {
+//    // In ARK identifiers hyphens are considered to be insignificant, that is why we here
+//    // add the hyphens to a uuid string that doesn't contain any hyphens and whose length is 32 characters
+//    // (lenghth of a valid UUID without hyphens).
+//    if (!uuid.contains("-") && uuid.length == 32)
+//      s"${ uuid.slice(0, 8) }-${ uuid.slice(8, 12) }-${ uuid.slice(12, 16) }-${ uuid.slice(16, 20) }-${ uuid.slice(20, 32) }"
+//    else
+//      uuid
+//  }
 
   private def getPath = Try {
     multiParams("splat").find(!_.trim.isEmpty).map(Paths.get(_))

--- a/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.download/EasyDownloadServlet.scala
@@ -61,16 +61,6 @@ class EasyDownloadServlet(app: EasyDownloadApp) extends ScalatraServlet
    params("uuid").toUUID.toTry
   }
 
-//  private def correctHyphenation(uuid: String): String = {
-//    // In ARK identifiers hyphens are considered to be insignificant, that is why we here
-//    // add the hyphens to a uuid string that doesn't contain any hyphens and whose length is 32 characters
-//    // (lenghth of a valid UUID without hyphens).
-//    if (!uuid.contains("-") && uuid.length == 32)
-//      s"${ uuid.slice(0, 8) }-${ uuid.slice(8, 12) }-${ uuid.slice(12, 16) }-${ uuid.slice(16, 20) }-${ uuid.slice(20, 32) }"
-//    else
-//      uuid
-//  }
-
   private def getPath = Try {
     multiParams("splat").find(!_.trim.isEmpty).map(Paths.get(_))
   }

--- a/src/test/scala/nl.knaw.dans.easy.download/ServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.download/ServletSpec.scala
@@ -242,29 +242,12 @@ class ServletSpec extends TestSupportFixture with EmbeddedJettyContainer
     }
   }
 
-  it should "accept uuid without hyphens" in {
+  it should "not accept uuid without hyphens" in {
     val uuidWithoutHyphens = uuid.toString.replace("-", "")
     val path = Paths.get("data/some.file")
-    expectAuthentication(0)
-    expectDownloadStream(uuid, path) returning (os => {
-      os().write(s"content of $uuid/$path ")
-      Success(())
-    })
-    expectLoadDdm(uuid) returning Try(datasetXml)
-    expectAuthorisation(path) returning Success(
-      s"""{
-         |  "itemId":"$uuid/$path",
-         |  "owner":"someone",
-         |  "dateAvailable":"1992-07-30",
-         |  "accessibleTo":"ANONYMOUS",
-         |  "visibleTo":"ANONYMOUS",
-         |  "licenseKey":"",
-         |  "licenseTitle":""
-         |}""".stripMargin
-    )
     get(s"ark:/$naan/$uuidWithoutHyphens/$path") {
-      body shouldBe s"content of $uuid/$path "
-      status shouldBe OK_200
+      body should include("is not a UUID")
+      status shouldBe NOT_FOUND_404
     }
   }
 


### PR DESCRIPTION
Fixes EASY-2569

#### When applied it will
* Make hyphens in the UUID part of the item-id mandatory again.

#### Where should the reviewer @DANS-KNAW/easy start?


